### PR TITLE
chore(readme): update npm install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Multiple submodules (eg, `empathic/find`) are offered, _each of which_ are:
 ## Install
 
 ```sh
-$ npm install empathic
+npm install empathic
 ```
 
 ## Usage


### PR DESCRIPTION
- Remove `$` from npm command

What shell the user is isn't important and having the `$` shell indicator makes copy pasting this command from the readme fail in terminal.