### PR TITLE
fix: Use `default` export conditions instead of `import`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,23 +12,23 @@
 	"exports": {
 		"./access": {
 			"types": "./access.d.mts",
-			"import": "./access.mjs"
+			"default": "./access.mjs"
 		},
 		"./find": {
 			"types": "./find.d.mts",
-			"import": "./find.mjs"
+			"default": "./find.mjs"
 		},
 		"./package": {
 			"types": "./package.d.mts",
-			"import": "./package.mjs"
+			"default": "./package.mjs"
 		},
 		"./resolve": {
 			"types": "./resolve.d.mts",
-			"import": "./resolve.mjs"
+			"default": "./resolve.mjs"
 		},
 		"./walk": {
 			"types": "./walk.d.mts",
-			"import": "./walk.mjs"
+			"default": "./walk.mjs"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
This change allows the package to be imported with `require(esm)`

This is what is shown with the current export conditions:
<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/8b2f8e33-d15c-45fb-9572-cdb283d7c2a6)

</details>

But it works with `default`:
<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/bcaddf12-5e39-4f87-beca-8ec3ef2b3a0b)

</details>

And older node versions without `require(esm)` get a clearer error:
<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/1225d392-d2d8-4aa5-8a22-f3bc8862c825)

</details>
