### PR TITLE
fix: add esm types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,27 +11,22 @@
 	},
 	"exports": {
 		"./access": {
-			"types": "./access.d.ts",
 			"import": "./access.mjs",
 			"require": "./access.js"
 		},
 		"./find": {
-			"types": "./find.d.ts",
 			"import": "./find.mjs",
 			"require": "./find.js"
 		},
 		"./package": {
-			"types": "./package.d.ts",
 			"import": "./package.mjs",
 			"require": "./package.js"
 		},
 		"./resolve": {
-			"types": "./resolve.d.ts",
 			"import": "./resolve.mjs",
 			"require": "./resolve.js"
 		},
 		"./walk": {
-			"types": "./walk.d.ts",
 			"import": "./walk.mjs",
 			"require": "./walk.js"
 		},

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -62,11 +62,16 @@ async function transform(filename: string) {
 	let rgx = /\.tsx?$/;
 	let cjs = filename.replace(rgx, '.js');
 	let esm = filename.replace(rgx, '.mjs');
-	let dts = filename.replace(rgx, '.d.ts');
+	let dtsCjs = filename.replace(rgx, '.d.ts');
+	let dtsEsm = filename.replace(rgx, '.d.mts');
 
-	let outfile = join(outdir, dts);
-	log('> writing "%s" file', dts);
+	let outfile = join(outdir, dtsCjs);
+	log('> writing "%s" file', dtsCjs);
 	await Deno.writeTextFile(outfile, xform.declaration!);
+
+	outfile = join(outdir, dtsEsm);
+	log('> writing "%s" file', dtsEsm);
+	await Deno.writeTextFile(outfile, `export * from './${cjs}';\n`);
 
 	outfile = join(outdir, esm);
 	log('> writing "%s" file', esm);


### PR DESCRIPTION
fix #10

fixes the issue described in https://github.com/lukeed/empathic/issues/10#issuecomment-3155902675

I've tested locally and `import f from 'empathic/find'` will now correctly error in typescript instead of only finding out in runtime.