### PR TITLE
chore: prepare for trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Build
         run: deno task build --quiet
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,9 @@ jobs:
           deno-version: ${{ env.DENO_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
+          
       - name: Build
         run: deno task build --quiet
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
       - name: Build
         run: deno task build --quiet
 
@@ -117,12 +120,8 @@ jobs:
         if: ${{ !contains(github.ref, '-next.') }}
         run: npm publish --provenance --access public
         working-directory: ./npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: 'Publish → npm (pre-release)'
         if: ${{ contains(github.ref, '-next.') }}
         run: npm publish --tag next --provenance --access public
         working-directory: ./npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removes token environment variables and installs latest npm (to support
trusted publishing).

If we're not a fan of installing latest npm, we can also bump Node to a version which supports trusted publishing out of the box.

In npm you need to add the `ci.yml` workflow as a trusted publisher and disable tokens without 2FA.
